### PR TITLE
MVP: Evaluate different kernels with a workload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+lsm-perf.csv
+workloads/eventfd

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The `bzImage` of the kernels to be tested are required. You can build them from 
 
 You also need a filesystem image disk (`.img`) into which you can SSH as the root user without needing a password. You might need to create an rsa key and add it in the filesystem image disk as an authorized key. Instructions for this are [here](http://www.linuxproblem.org/art_9.html).
 
-Finally, you need a compiled workload. It should run many times a function with critical performances that you aim to improve, and output the running time in stdout. This should be the only thing printed to stdout. Workload samples are provided in `wokloads/`, you just need to compile them with `gcc <some workload>.c -o <some workload>`.
+Finally, you need a compiled workload. It should run many times a function with critical performances that you aim to improve, and output the running time in stdout. This should be the only thing printed to stdout. Workload samples are provided in `wokloads/`, you just need to compile them with `make <some workload>`.
 
 
 ## Run

--- a/README.md
+++ b/README.md
@@ -1,1 +1,79 @@
-# lsm-perf
+# LSM Perf
+This tool is to evaluate and compare the performances of different kernel implementations for syscalls. Specifically, it starts a qemu virtual machine with each kernel, runs a workload that triggers many system calls, and report the results. This is particularly useful to evaluate the cost of a Linux Security Module (LSM).
+
+## Requirements
+### Installation
+You need the following installed on your system:
+- [Python 3](https://www.python.org/downloads/) 
+- The [plumbum library](https://pypi.org/project/plumbum/) (`pip install plumbum`)
+- [Qemu](https://www.qemu.org/download/) (`apt-get install qemu`)
+
+### Files
+The `bzImage` of the kernels to be tested are required. You can build them from the [Linux](https://github.com/torvalds/linux) codebase. 
+
+You also need a filesystem image disk (`.img`) into which you can SSH as the root user without needing a password. You might need to create an rsa key and add it in the filesystem image disk as an authorized key. Instructions for this are [here](http://www.linuxproblem.org/art_9.html).
+
+Finally, you need a compiled workload. It should run many times a function with critical performances that you aim to improve, and output the running time in stdout. This should be the only thing printed to stdout. Workload samples are provided in `wokloads/`, you just need to compile them with `gcc <some workload>.c -o <some workload>`.
+
+
+## Run
+
+
+Usage:
+``` 
+lsm-perf.py [-h] -i IMAGE -k KERNELS [KERNELS ...] -w WORKLOAD
+                   [-key KEY] [-o OUT]
+
+Compares the performances of several kernels on the same workload.
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -i IMAGE, --image IMAGE
+                        Path of the disk image to boot the kernels from.
+  -k KERNELS [KERNELS ...], --kernels KERNELS [KERNELS ...]
+                        Path of all the kernels to evaluate.
+  -w WORKLOAD, --workload WORKLOAD
+                        Path of the workload program to run to evaluate the
+                        kernels. This should take no argument, and simply
+                        output an integer to stdout (the time measurement)
+  -key KEY              Path of the RSA key to connect to the VM. It must be
+                        in the list of authorized keys in the image.
+  -o OUT, --out OUT     Path of the output file.
+```
+
+You can give as many kernels as you want (`-k`). They will all be evaluated several times and the results will be written in the output file (`-o`). You also need to provide the image (`-i`) with the authorized ssh key (-`key`). The progress will be displayed in stdout.
+
+## Example 
+
+Run (in progress) example:
+
+```
+$ python3 lsm-perf.py -i ../../images/debian.img -k ../../images/alllsm ../../images/bpflsm ../../images/paulsm ../../images/nolsm -w workloads/eventfd -key ****
+Starting round 0
+        Evaluating alllsm: 100% average=634125, stdev=6516                    
+        Evaluating bpflsm: 100% average=591334, stdev=5978                    
+        Evaluating paulsm: 100% average=592567, stdev=7477                    
+        Evaluating nolsm: 100%  average=565212, stdev=10426                    
+Starting round 1
+        Evaluating alllsm: 100% average=641875, stdev=3505                    
+        Evaluating bpflsm: 100% average=594381, stdev=8446                    
+        Evaluating paulsm: 80%                              
+```
+
+Output file content example:
+
+```
+kernel path,round,run 0,run 1,run 2,run 3,run 4,run 5,run 6,run 7,run 8,run 9
+../../images/alllsm,0,632534,637162,633624,639046,640437,632283,638391,621850,624864,641063
+../../images/bpflsm,0,588247,589773,592864,586622,592978,601313,590462,579478,594899,596710
+../../images/paulsm,0,585694,600144,584909,585880,598131,597167,605159,583542,591269,593776
+../../images/nolsm,0,572458,558261,553266,574269,572572,569700,568683,549366,579234,554316
+../../images/alllsm,1,644304,639634,637911,643676,647124,635481,641246,642767,645180,641430
+../../images/bpflsm,1,585039,584189,591454,598259,599099,613591,593824,595055,588458,594850
+../../images/paulsm,1,585049,582425,602832,588233,584257,597798,600553,592897,599376,596029
+../../images/nolsm,1,559117,571304,560387,574854,580482,570355,561769,565104,575381,567941
+../../images/alllsm,2,623583,630186,621311,642966,621754,628041,628981,639126,638830,642383
+../../images/bpflsm,2,586485,600646,587043,590295,601922,587821,584644,592760,590667,581323
+../../images/paulsm,2,583044,577246,580257,586506,593093,591338,596610,579747,588739,584627
+../../images/nolsm,2,562076,564104,570189,570115,557956,564576,574262,558895,574167,569505
+```

--- a/lsm-perf.py
+++ b/lsm-perf.py
@@ -36,8 +36,7 @@ def main(args):
 
 
 def evaluating_kernel(kernel_path, img_path, workload_path, keyfile):
-    """
-    Starts a VM with the kernel and evaluates its 
+    """Starts a VM with the kernel and evaluates its
     performances on the provided workload
     """
     results = []
@@ -67,10 +66,9 @@ def evaluating_kernel(kernel_path, img_path, workload_path, keyfile):
 
 
 class VM:
-"""
-Represents a qemu VM with an SSH connection.
-To use with the `with` construct
-"""
+    """Represents a qemu VM with an SSH connection.
+    To use with the `with` construct
+    """
     def __init__(self, kernel_path, img_path, keyfile):
         """Starts the qemu VM"""
         qemu_args = construct_qemu_args(kernel_path, img_path)

--- a/lsm-perf.py
+++ b/lsm-perf.py
@@ -209,7 +209,8 @@ def parse_args():
               'This should take no argument, and simply output an integer '
               'to stdout (the time measurement)'))
     parser.add_argument(
-        '-key', type=argparse.FileType('r'), default='~/.ssh/id_rsa',
+        '-key', type=argparse.FileType('r'),
+        default=os.path.expanduser('~/.ssh/id_rsa'),
         help=('Path of the RSA key to connect to the VM. '
               'It must be in the list of authorized keys in the image.'))
     parser.add_argument(

--- a/lsm-perf.py
+++ b/lsm-perf.py
@@ -7,63 +7,62 @@ from plumbum import local, SshMachine # TODO: requirements
 
 
 NUMBER_OF_ROUNDS = 1
+NUMBER_OF_REPETITIONS = 2
+ON_VM_WORKLOAD_PATH = "~/lsm-perf-workload"
 QEMU_EXIT_CMD=b'\x01cq\n' # -> ctrl+a c q
-
-
-def evaluating_kernel(kernel_path, img_path, workload_path):
-    with VM(kernel_path, img_path) as vm:
-        print('\tEvaluating %s' % vm.name)
-        conn = vm.ssh()
-        print(conn['ls']())
-        vm.scp_to(workload_path, "~/lsm-perf-workload")
-        print(conn['ls']())
-        work_cmd = conn['~/lsm-perf-workload']
-        results = [work_cmd() for _ in range(10)]
-        print(results)
-
-
-class VM:
-    def __init__(self, kernel_path, img_path):
-        self.process = local['vm'].popen(['start', '-k', kernel_path, '-i', img_path])
-        self.name = kernel_path[kernel_path.rfind('/') + 1:]
-        self.ssh_con = None
-
-    def ssh(self, keyfile='~/.ssh/id_rsa_nopassw'):
-        c = 5
-        while self.ssh_con is None:
-            time.sleep(1)
-            try: 
-                self.ssh_con = SshMachine('127.0.0.1', user='root', port=5555, keyfile=keyfile)
-            except (EOFError, plumbum.machines.session.SSHCommsError) as e:
-                c -= 1
-                if c == 0:
-                    raise e
-                else:
-                    print('Failed to ssh, retrying...')
-        return self.ssh_con
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, type, value, traceback):
-        if self.ssh_con is not None:
-            self.ssh_con.close()
-            self.ssh_con = None
-        self.process.stdin.write(QEMU_EXIT_CMD)
-
-    def scp_to(self, src_local, dst_remote):
-        assert self.ssh_con is not None
-        fro = local.path(src_local)
-        to = self.ssh_con.path(dst_remote)
-        plumbum.path.utils.copy(fro, to)
 
 
 def main(args):
     for round in range(NUMBER_OF_ROUNDS):
         print('Starting round %d' % round)
         for kernel in args.kernels:
-            evaluating_kernel(kernel.name, args.image.name, args.workload.name)
+            evaluating_kernel(kernel.name, args.image.name, args.workload.name, args.key.name)
     return 0
+
+
+def evaluating_kernel(kernel_path, img_path, workload_path, keyfile):
+    with VM(kernel_path, img_path, keyfile) as vm:
+        print('\tEvaluating %s: ' % vm.name)
+        print(vm.ssh['ls']())
+        vm.scp_to(workload_path, ON_VM_WORKLOAD_PATH)
+        print(vm.ssh['ls']())
+        work_cmd = vm.ssh[ON_VM_WORKLOAD_PATH]
+        results = [int(work_cmd().strip()) for _ in range(NUMBER_OF_REPETITIONS)]
+        vm.ssh['rm'][ON_VM_WORKLOAD_PATH]()
+        print(results)
+
+
+class VM:
+    def __init__(self, kernel_path, img_path, keyfile):
+        self.process = local['vm'].popen(['start', '-k', kernel_path, '-i', img_path])
+        self.name = kernel_path[kernel_path.rfind('/') + 1:]
+        self.ssh = None
+        self.key = keyfile
+
+    def __enter__(self):
+        # Initialize ssh connection
+        c = 5
+        while self.ssh is None:
+            time.sleep(1)
+            try: 
+                self.ssh = SshMachine('127.0.0.1', user='root', port=5555, keyfile=self.key)
+            except (EOFError, plumbum.machines.session.SSHCommsError) as e:
+                c -= 1
+                if c == 0:
+                    raise e
+        return self
+
+    def __exit__(self, type, value, traceback):
+        if self.ssh is not None:
+            self.ssh.close()
+            self.ssh = None
+        self.process.stdin.write(QEMU_EXIT_CMD)
+
+    def scp_to(self, src_local, dst_remote):
+        assert self.ssh is not None
+        fro = local.path(src_local)
+        to = self.ssh.path(dst_remote)
+        plumbum.path.utils.copy(fro, to)
 
 
 def parse_args():
@@ -77,6 +76,10 @@ def parse_args():
                         help='Path of the workload program to run to evaluate the kernels. ' +
                         'This should take no argument, and simply output an integer to stdout ' +
                         '(the time measurement)')
+    parser.add_argument('-key', type=argparse.FileType('r'), default='~/.ssh/id_rsa', 
+                        help='Path of the RSA key to connect to the VM. ' + 
+                        'It must be in the list of authorized keys in the image.')
+    
     return parser.parse_args()
 
 

--- a/lsm-perf.py
+++ b/lsm-perf.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env
+
+import argparse
+import time
+import plumbum
+from plumbum import local, SshMachine # TODO: requirements
+
+
+NUMBER_OF_ROUNDS = 1
+QEMU_EXIT_CMD=b'\x01cq\n' # -> ctrl+a c q
+
+
+def evaluating_kernel(kernel_path, img_path, workload_path):
+    with VM(kernel_path, img_path) as vm:
+        print('\tEvaluating %s' % vm.name)
+        conn = vm.ssh()
+        print(conn['ls']())
+        vm.scp_to(workload_path, "~/lsm-perf-workload")
+        print(conn['ls']())
+        work_cmd = conn['~/lsm-perf-workload']
+        results = [work_cmd() for _ in range(10)]
+        print(results)
+
+
+class VM:
+    def __init__(self, kernel_path, img_path):
+        self.process = local['vm'].popen(['start', '-k', kernel_path, '-i', img_path])
+        self.name = kernel_path[kernel_path.rfind('/') + 1:]
+        self.ssh_con = None
+
+    def ssh(self, keyfile='~/.ssh/id_rsa_nopassw'):
+        c = 5
+        while self.ssh_con is None:
+            time.sleep(1)
+            try: 
+                self.ssh_con = SshMachine('127.0.0.1', user='root', port=5555, keyfile=keyfile)
+            except (EOFError, plumbum.machines.session.SSHCommsError) as e:
+                c -= 1
+                if c == 0:
+                    raise e
+                else:
+                    print('Failed to ssh, retrying...')
+        return self.ssh_con
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, traceback):
+        if self.ssh_con is not None:
+            self.ssh_con.close()
+            self.ssh_con = None
+        self.process.stdin.write(QEMU_EXIT_CMD)
+
+    def scp_to(self, src_local, dst_remote):
+        assert self.ssh_con is not None
+        fro = local.path(src_local)
+        to = self.ssh_con.path(dst_remote)
+        plumbum.path.utils.copy(fro, to)
+
+
+def main(args):
+    for round in range(NUMBER_OF_ROUNDS):
+        print('Starting round %d' % round)
+        for kernel in args.kernels:
+            evaluating_kernel(kernel.name, args.image.name, args.workload.name)
+    return 0
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description=
+                        'Compares the performances of several kernels on the same workload.')
+    parser.add_argument('-i', '--image', type=argparse.FileType('r'), required=True, 
+                        help='Path of the disk image to boot the kernels from.')
+    parser.add_argument('-k', '--kernels', type=argparse.FileType('r'), nargs='+', required=True, 
+                        help='Path of all the kernels to evaluate.')
+    parser.add_argument('-w', '--workload', type=argparse.FileType('r'), required=True, 
+                        help='Path of the workload program to run to evaluate the kernels. ' +
+                        'This should take no argument, and simply output an integer to stdout ' +
+                        '(the time measurement)')
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    main(parse_args())

--- a/lsm-perf.py
+++ b/lsm-perf.py
@@ -116,7 +116,7 @@ class VM:
                 err = e
                 continue
         else:  # Reached maximum retries
-            raise VM.VMException(
+            raise VMException(
                 'SSH connection failed after too many retries', err)
         return self
 
@@ -136,7 +136,7 @@ class VM:
                             i.e. when not used inside a `with` block
         """
         if self.ssh is None:
-            raise VM.VMException(
+            raise VMException(
                 '`VM.scp_to` must be used with an established SSH connection, '
                 'i.e. inside a `with` block.')
         src = local.path(src_local)
@@ -166,9 +166,10 @@ class VM:
             '-name', 'lsm_perf_vm,debug-threads=on'
         ]
 
-    class VMException(Exception):
-        """Exceptions specific to the VM class"""
-        pass
+
+class VMException(Exception):
+    """Exceptions specific to the VM class"""
+    pass
 
 
 def print_eta(kernel_name, info=""):

--- a/lsm-perf.py
+++ b/lsm-perf.py
@@ -5,6 +5,7 @@ import time
 import plumbum
 import sys
 import statistics
+import os
 from plumbum import local, SshMachine  # TODO: requirements
 
 
@@ -23,7 +24,7 @@ def main(args):
             for kernel in args.kernels:
                 results = evaluating_kernel(
                     kernel_path=kernel.name,
-                    img_path=args.image.name,
+                    filesystem_path=args.image.name,
                     workload_path=args.workload.name,
                     keyfile=args.key.name
                 )
@@ -35,15 +36,15 @@ def main(args):
     return 0
 
 
-def evaluating_kernel(kernel_path, img_path, workload_path, keyfile):
+def evaluate_kernel(kernel_path, filesystem_path, workload_path, keyfile):
     """Starts a VM with the kernel and evaluates its
     performances on the provided workload
     """
     results = []
-    name = kernel_path[kernel_path.rfind('/') + 1:]
+    name = os.path.basename(kernel_path)
     print_eta(name, info='connecting')
 
-    with VM(kernel_path, img_path, keyfile) as vm:
+    with VM(kernel_path, filesystem_path, keyfile) as vm:
         vm.scp_to(workload_path, ON_VM_WORKLOAD_PATH)
         work_cmd = vm.ssh[ON_VM_WORKLOAD_PATH]
 
@@ -69,9 +70,9 @@ class VM:
     """Represents a qemu VM with an SSH connection.
     To use with the `with` construct
     """
-    def __init__(self, kernel_path, img_path, keyfile):
+    def __init__(self, kernel_path, filesystem_path, keyfile):
         """Starts the qemu VM"""
-        qemu_args = construct_qemu_args(kernel_path, img_path)
+        qemu_args = construct_qemu_args(kernel_path, filesystem_path)
         self.process = local['qemu-system-x86_64'].popen(qemu_args)
         self.ssh = None
         self.key = keyfile
@@ -107,7 +108,7 @@ class VM:
         plumbum.path.utils.copy(fro, to)
 
 
-def construct_qemu_args(kernel_path, img_path):
+def construct_qemu_args(kernel_path, filesystem_path):
     """Qemu arguments similar to what `vm start` produces"""
     return [
         '-nographic',
@@ -119,7 +120,7 @@ def construct_qemu_args(kernel_path, img_path):
         '-append', 'console=ttyS0,115200 root=/dev/sda rw nokaslr',
         '-smp', '4',
         '-m', '4G',
-        '-drive', 'if=none,id=hd,file=%s,format=raw' % img_path,
+        '-drive', 'if=none,id=hd,file=%s,format=raw' % filesystem_path,
         '-device', 'virtio-scsi-pci,id=scsi',
         '-device', 'scsi-hd,drive=hd',
         '-device', 'virtio-rng-pci,max-bytes=1024,period=1000',

--- a/workloads/Makefile
+++ b/workloads/Makefile
@@ -2,7 +2,7 @@ CC = gcc
 CFLAGS  = -Wall
 
 # the build target executable:
-TARGETS = eventfd eventfd2
+TARGETS = eventfd
 
 all: $(TARGETS)
 

--- a/workloads/Makefile
+++ b/workloads/Makefile
@@ -1,0 +1,10 @@
+CC = gcc
+CFLAGS  = -Wall
+
+# the build target executable:
+TARGETS = eventfd eventfd2
+
+all: $(TARGETS)
+
+clean:
+	$(RM) $(TARGETS)

--- a/workloads/eventfd.c
+++ b/workloads/eventfd.c
@@ -16,7 +16,7 @@ int main(void) {
         start = clock();
         while (c--) eventfd_write(fd, 1);
         end = clock();
-        printf("%d\n", end - start);
+        printf("%ld\n", end - start);
 
         nanosleep(&tim, NULL);
         return 0;

--- a/workloads/eventfd.c
+++ b/workloads/eventfd.c
@@ -1,0 +1,24 @@
+#include <sys/eventfd.h>
+#include <unistd.h>
+#include <time.h>
+#include <stdio.h>
+
+int main(void) {
+        int fd = eventfd(0, 0);
+        int c = 1000 * 1000;
+        clock_t start, end;
+
+        struct timespec tim;
+        tim.tv_sec = 0;
+        tim.tv_nsec = 200L * 1000L * 1000L;
+        nanosleep(&tim, NULL);
+
+        start = clock();
+        while (c--) eventfd_write(fd, 1);
+        end = clock();
+        printf("%d\n", end - start);
+
+        nanosleep(&tim, NULL);
+        return 0;
+}
+


### PR DESCRIPTION
### MVP: Evaluate different kernels with a workload

Design Doc: [go/lsm-perf-dd](go/lsm-perf-dd)
`lsm-perf.py` takes several kernels as arguments and evaluates a workload several times on them. In each round, a qemu virtual machine is started for each kernel, the workload is transferred to it. Warmup runs are performed before evaluating the workload `REPETITIONS_PER_ROUND` times. The results are written back to a file, and a summary is displayed on the command line.

This also includes a workload `eventf.c` that measures the execution times of `eventfd_write`.

A future PR will introduce CPU management to run the workload on a dedicated CPU.

---
Usage:
```
lsm-perf.py [-h] -i IMAGE -k KERNELS [KERNELS ...] -w WORKLOAD
                   [-key KEY] [-o OUT]

Compares the performances of several kernels on the same workload.

optional arguments:
  -h, --help            show this help message and exit
  -i IMAGE, --image IMAGE
                        Path of the disk image to boot the kernels from.
  -k KERNELS [KERNELS ...], --kernels KERNELS [KERNELS ...]
                        Path of all the kernels to evaluate.
  -w WORKLOAD, --workload WORKLOAD
                        Path of the workload program to run to evaluate the
                        kernels. This should take no argument, and simply
                        output an integer to stdout (the time measurement)
  -key KEY              Path of the RSA key to connect to the VM. It must be
                        in the list of authorized keys in the image.
  -o OUT, --out OUT     Path of the output file.

```
Run (in progress) example:
```
$ python3 lsm-perf.py -i ../../images/debian.img -k ../../images/alllsm ../../images/bpflsm ../../images/paulsm ../../images/nolsm -w workloads/eventfd -key ****
Starting round 0
        Evaluating alllsm: 100% average=634125, stdev=6516                    
        Evaluating bpflsm: 100% average=591334, stdev=5978                    
        Evaluating paulsm: 100% average=592567, stdev=7477                    
        Evaluating nolsm: 100%  average=565212, stdev=10426                    
Starting round 1
        Evaluating alllsm: 100% average=641875, stdev=3505                    
        Evaluating bpflsm: 100% average=594381, stdev=8446                    
        Evaluating paulsm: 80%                              
      
```

Output file content example:
```
kernel path,round,run 0,run 1,run 2,run 3,run 4,run 5,run 6,run 7,run 8,run 9
../../images/alllsm,0,632534,637162,633624,639046,640437,632283,638391,621850,624864,641063
../../images/bpflsm,0,588247,589773,592864,586622,592978,601313,590462,579478,594899,596710
../../images/paulsm,0,585694,600144,584909,585880,598131,597167,605159,583542,591269,593776
../../images/nolsm,0,572458,558261,553266,574269,572572,569700,568683,549366,579234,554316
../../images/alllsm,1,644304,639634,637911,643676,647124,635481,641246,642767,645180,641430
../../images/bpflsm,1,585039,584189,591454,598259,599099,613591,593824,595055,588458,594850
../../images/paulsm,1,585049,582425,602832,588233,584257,597798,600553,592897,599376,596029
../../images/nolsm,1,559117,571304,560387,574854,580482,570355,561769,565104,575381,567941
../../images/alllsm,2,623583,630186,621311,642966,621754,628041,628981,639126,638830,642383
../../images/bpflsm,2,586485,600646,587043,590295,601922,587821,584644,592760,590667,581323
../../images/paulsm,2,583044,577246,580257,586506,593093,591338,596610,579747,588739,584627
../../images/nolsm,2,562076,564104,570189,570115,557956,564576,574262,558895,574167,569505

```
