### PR TITLE
CPU Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ You need the following installed on your system:
 - [Python 3](https://www.python.org/downloads/) 
 - The [plumbum library](https://pypi.org/project/plumbum/) (`pip install plumbum`)
 - [Qemu](https://www.qemu.org/download/) (`apt-get install qemu`)
+- [qemu-affinity](https://github.com/zegelin/qemu-affinity) if you want to use the CPU management.
 
 ### Files
 The `bzImage` of the kernels to be tested are required. You can build them from the [Linux](https://github.com/torvalds/linux) codebase. 
@@ -21,8 +22,8 @@ Finally, you need a compiled workload. It should run many times a function with 
 
 Usage:
 ``` 
-lsm-perf.py [-h] -i IMAGE -k KERNELS [KERNELS ...] -w WORKLOAD
-                   [-key KEY] [-o OUT]
+usage: lsm-perf.py [-h] -i IMAGE -k KERNELS [KERNELS ...] -w WORKLOAD
+                   [-key KEY] [-o OUT] [-c [CPU [CPU ...]]]
 
 Compares the performances of several kernels on the same workload.
 
@@ -39,9 +40,19 @@ optional arguments:
   -key KEY              Path of the RSA key to connect to the VM. It must be
                         in the list of authorized keys in the image.
   -o OUT, --out OUT     Path of the output file.
+  -c [CPU [CPU ...]], --cpu [CPU [CPU ...]]
+                        CPUs that should be used to run the VM. Provide three
+                        CPUs [x,y,z], qemus-system will be assigned to x, the
+                        two CPUs of the VM will be assigned to y and z
+                        respectively, and the workload will be run on y. These
+                        CPUs should be isolated (i.e. start your machine with
+                        `isolcpus=x,y`) Keep this list empty to not assign
+                        CPUs
 ```
 
 You can give as many kernels as you want (`-k`). They will all be evaluated several times and the results will be written in the output file (`-o`). You also need to provide the image (`-i`) with the authorized ssh key (-`key`). The progress will be displayed in stdout.
+
+You can use the CPU management with `-c`. This will assign the virtual machine's CPUs to the physical host's CPUs. You should also start the host with the kernel parameter `isolcpus=...`, so that the virtual machine will have dedicated CPUs. This ensures the most reliable benchmark measurements.
 
 ## Example 
 
@@ -49,6 +60,7 @@ Run (in progress) example:
 
 ```
 $ python3 lsm-perf.py -i ../../images/debian.img -k ../../images/alllsm ../../images/bpflsm ../../images/paulsm ../../images/nolsm -w workloads/eventfd -key ****
+No dedicated CPUs provided.
 Starting round 0
         Evaluating alllsm: 100% average=634125, stdev=6516                    
         Evaluating bpflsm: 100% average=591334, stdev=5978                    

--- a/README.md
+++ b/README.md
@@ -42,17 +42,17 @@ optional arguments:
   -o OUT, --out OUT     Path of the output file.
   -c [CPU [CPU ...]], --cpu [CPU [CPU ...]]
                         CPUs that should be used to run the VM. Provide three
-                        CPUs [x,y,z], qemus-system will be assigned to x, the
+                        CPUs [x,y,z], qemu-system will be assigned to x, the
                         two CPUs of the VM will be assigned to y and z
                         respectively, and the workload will be run on y. These
                         CPUs should be isolated (i.e. start your machine with
-                        `isolcpus=x,y`) Keep this list empty to not assign
+                        `isolcpus=x,y,z`). Keep this list empty to not assign
                         CPUs
 ```
 
 You can give as many kernels as you want (`-k`). They will all be evaluated several times and the results will be written in the output file (`-o`). You also need to provide the image (`-i`) with the authorized ssh key (-`key`). The progress will be displayed in stdout.
 
-You can use the CPU management with `-c`. This will assign the virtual machine's CPUs to the physical host's CPUs. You should also start the host with the kernel parameter `isolcpus=...`, so that the virtual machine will have dedicated CPUs. This ensures the most reliable benchmark measurements.
+You can use the CPU management with `-c`. This will assign the virtual machine's CPUs to the physical host's CPUs. You should also start the host with the kernel parameter `isolcpus=...`, so that the virtual machine will have dedicated CPUs. This ensures the most reliable benchmark measurements. It is also recommended to start your machine in non-graphical mode.
 
 ## Example 
 

--- a/lsm-perf.py
+++ b/lsm-perf.py
@@ -18,8 +18,11 @@ ON_VM_WORKLOAD_CPU = 0
 HOST_PORT = 5555
 SSH_MAX_RETRY = 5
 
-QEMU_AFFINITY_PATH = '../qemu-affinity/qemu_affinity.py'  # TODO: make generic
+# TODO(renauld): make generic
+QEMU_AFFINITY_PATH = '../qemu-affinity/qemu_affinity.py'
 
+
+"""Holds the assignment of physical CPUs"""
 CPU_Allocation = collections.namedtuple('CPU_Allocation',
                                         ('qemu_sys', 'host_kvm0', 'host_kvm1'))
 
@@ -30,7 +33,6 @@ def main(args):
                'machine with `isolcpus=%s`.') % ','.join(map(str, args.cpu)))
         alloc = CPU_Allocation(qemu_sys=args.cpu[0], host_kvm0=args.cpu[1],
                                host_kvm1=args.cpu[2])
-        print(alloc)
     else:
         print('No dedicated CPUs provided.')
         alloc = None
@@ -70,9 +72,11 @@ def evaluate_kernel(kernel_path, filesystem_img_path, workload_path,
     """
     results = []
     name = os.path.basename(kernel_path)
+    isolcpus = [ON_VM_WORKLOAD_CPU] if cpus else []
     print_eta(name, info='connecting')
 
-    with VM(kernel_path, filesystem_img_path, keyfile, cpus) as vm:
+    with VM(kernel_path, filesystem_img_path, keyfile,
+            cpus, isolcpus) as vm:
         vm.scp_to(workload_path, ON_VM_WORKLOAD_PATH)
 
         work_cmd = vm.ssh[ON_VM_WORKLOAD_PATH]
@@ -118,24 +122,26 @@ class VM:
             vm.shh['ls']
     """
 
-    def __init__(self, kernel_path, filesystem_img_path, keyfile, cpus=None):
+    def __init__(self, kernel_path, filesystem_img_path, keyfile,
+                 cpu_allocation=None, isolcpus=[]):
         """Start the qemu VM (non blocking)
 
         :param kernel_path: Path of the kernel's bzImage
         :param filesystem_img_path: Path of the filesystem image (.img)
         :param keyfile: Path of rsa key that is authorized on the image
-        :param cpus: CPU_Allocation for qemu and the vm's cores,
-                     or None to not assign CPUs
+        :param cpu_allocation: CPU_Allocation for qemu and the vm's cores,
+                               or None to not assign CPUs
+        :param isolcpus: list of CPU ID that should be isolated at boot time
         """
         qemu_args = VM.__construct_qemu_args(
             kernel_path=kernel_path,
             filesystem_img_path=filesystem_img_path,
-            isolcpus=[ON_VM_WORKLOAD_CPU] if cpus else [])
+            isolcpus=isolcpus)
         self.process = local['qemu-system-x86_64'].popen(qemu_args)
         self.ssh = None
         self.key = keyfile
-        if cpus:
-            VM.__qemu_affinity_setup(self.process.pid, cpus)
+        if cpu_allocation:
+            VM.__qemu_affinity_setup(self.process.pid, cpu_allocation)
 
     def __enter__(self):
         """Initialize the ssh connection (blocks until success)"""
@@ -212,7 +218,7 @@ class VM:
         """Run qemu_affinity.py to allocate CPUs based on the CPU_Allocation"""
         system_affinities = ('-p %(sys)d -i *:%(sys)d -q %(sys)d -w *:%(sys)d'
                              % {'sys': cpu_alloc.qemu_sys}).split(' ')
-        kvm_affinities = ['-k', str(cpu_alloc.host_kvm0), 
+        kvm_affinities = ['-k', str(cpu_alloc.host_kvm0),
                                 str(cpu_alloc.host_kvm1)]
         args = system_affinities + kvm_affinities + ['--', str(qemu_pid)]
         cmd = plumbum.cmd.sudo['python3'][QEMU_AFFINITY_PATH][args]
@@ -270,12 +276,12 @@ def parse_args():
         help='Path of the output file.')
     parser.add_argument(
         '-c', '--cpu', type=int, default=[], nargs='*',
-        help=('CPUs that should be used to run the VM. \n'
-              'Provide three CPUs [x,y,z], qemus-system will be assigned '
+        help=('CPUs that should be used to run the VM. '
+              'Provide three CPUs [x,y,z], qemu-system will be assigned '
               'to x, the two CPUs of the VM will be assigned to y and z '
               'respectively, and the workload will be run on y. '
               'These CPUs should be isolated '
-              '(i.e. start your machine with `isolcpus=x,y`)\n'
+              '(i.e. start your machine with `isolcpus=x,y,z`). '
               'Keep this list empty to not assign CPUs'))
     args = parser.parse_args()
     if len(args.cpu) not in [0, 3]:

--- a/lsm-perf.py
+++ b/lsm-perf.py
@@ -75,8 +75,7 @@ def evaluate_kernel(kernel_path, filesystem_img_path, workload_path,
     isolcpus = [ON_VM_WORKLOAD_CPU] if cpus else []
     print_eta(name, info='connecting')
 
-    with VM(kernel_path, filesystem_img_path, keyfile,
-            cpus, isolcpus) as vm:
+    with VM(kernel_path, filesystem_img_path, keyfile, cpus, isolcpus) as vm:
         vm.scp_to(workload_path, ON_VM_WORKLOAD_PATH)
 
         work_cmd = vm.ssh[ON_VM_WORKLOAD_PATH]


### PR DESCRIPTION
Enable the binding of VM's CPUs with host's CPUs

(Depends on https://github.com/PaulRenauld/lsm-perf/pull/1)

This gives the option to the user to use more advanced CPU management with the `-c` flag. When provided with three CPUs x, y and z, x will be used for the I/O and the handling of qemu-system, y will be bound to CPU 0 of the VM, and z to CPU 1. Then, the VM is started with `isolcpus=0` and the workload is run on CPU 0. This means that the workload used a dedicated CPU which should improve the reliability of the measurements. 
The user also needs to start their computer with the kernel option `isolcpus=x,y,z` to unsure that these CPUs are not used for anything else.

For now, [qemu-affinity](https://github.com/zegelin/qemu-affinity) must be cloned and the path to `qemu_affinity.py` must be in `QEMU_AFFINITY_PATH`. This is temporary. The reason is that qemu-affinity needs to be run with `sudo`, which is hard to use with `pip`.
