### PR TITLE
Clean up to be ready for general usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-lsm-perf.csv
+*.csv
 workloads/eventfd

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "qemu-affinity"]
+	path = qemu-affinity
+	url = https://github.com/zegelin/qemu-affinity

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ You need the following installed on your system:
 - [Python 3](https://www.python.org/downloads/) 
 - The [plumbum library](https://pypi.org/project/plumbum/) (`pip install plumbum`)
 - [Qemu](https://www.qemu.org/download/) (`apt-get install qemu`)
-- [qemu-affinity](https://github.com/zegelin/qemu-affinity) if you want to use the CPU management.
+- [qemu-affinity](https://github.com/zegelin/qemu-affinity) if you want to use the CPU management. This is provided as a git submodule, so clone this repository with `git clone --recursive https://github.com/PaulRenauld/lsm-perf.git`. If you already cloned the repository without the recursive option, just run `git submodule update --init --recursive`
 
 ### Files
 The `bzImage` of the kernels to be tested are required. You can build them from the [Linux](https://github.com/torvalds/linux) codebase. 
@@ -23,7 +23,8 @@ Finally, you need a compiled workload. It should run many times a function with 
 Usage:
 ``` 
 usage: lsm-perf.py [-h] -i IMAGE -k KERNELS [KERNELS ...] -w WORKLOAD
-                   [-key KEY] [-o OUT] [-c CPU-QEMU CPU-KVM1 CPU-KVM2]
+                   [--key KEY] [-o OUT] [-c CPU-QEMU CPU-KVM1 CPU-KVM2]
+                   [--runs RUNS] [--rounds ROUNDS] [--warmups WARMUPS]
 
 Compares the performances of several kernels on the same workload.
 
@@ -37,7 +38,7 @@ optional arguments:
                         Path of the workload program to run to evaluate the
                         kernels. This should take no argument, and simply
                         output an integer to stdout (the time measurement)
-  -key KEY              Path of the RSA key to connect to the VM. It must be
+  --key KEY             Path of the RSA key to connect to the VM. It must be
                         in the list of authorized keys in the image.
   -o OUT, --out OUT     Path of the output file.
   -c CPU-QEMU CPU-KVM1 CPU-KVM2, --cpu CPU-QEMU CPU-KVM1 CPU-KVM2
@@ -48,9 +49,16 @@ optional arguments:
                         KVM1`. These CPUs should be isolated (i.e. start your
                         machine with `isolcpus=CPU-QEMU,CPU-KVM1,CPU-KVM2`.
                         Omit this parameter to not assign CPUs
+  --runs RUNS           Number of times the workload should be evaluated for
+                        each kernel in each round.
+  --rounds ROUNDS       Number of times the tested are repeated and the VMs
+                        restarted.
+  --warmups WARMUPS     Number of times the workload will be run but not
+                        measured after starting the VM.
+
 ```
 
-You can give as many kernels as you want (`-k`). They will all be evaluated several times and the results will be written in the output file (`-o`). You also need to provide the image (`-i`) with the authorized ssh key (-`key`). The progress will be displayed in stdout.
+You can give as many kernels as you want (`-k`). They will all be evaluated several times and the results will be written in the output file (`-o`). You also need to provide the image (`-i`) with the authorized ssh key (`--key`). The progress will be displayed in stdout.
 
 You can use the CPU management with `-c`. This will assign the virtual machine's CPUs to the physical host's CPUs. You should also start the host with the kernel parameter `isolcpus=...`, so that the virtual machine will have dedicated CPUs. This ensures the most reliable benchmark measurements. It is also recommended to start your machine in non-graphical mode.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Finally, you need a compiled workload. It should run many times a function with 
 Usage:
 ``` 
 usage: lsm-perf.py [-h] -i IMAGE -k KERNELS [KERNELS ...] -w WORKLOAD
-                   [-key KEY] [-o OUT] [-c [CPU [CPU ...]]]
+                   [-key KEY] [-o OUT] [-c CPU-QEMU CPU-KVM1 CPU-KVM2]
 
 Compares the performances of several kernels on the same workload.
 
@@ -40,14 +40,14 @@ optional arguments:
   -key KEY              Path of the RSA key to connect to the VM. It must be
                         in the list of authorized keys in the image.
   -o OUT, --out OUT     Path of the output file.
-  -c [CPU [CPU ...]], --cpu [CPU [CPU ...]]
-                        CPUs that should be used to run the VM. Provide three
-                        CPUs [x,y,z], qemu-system will be assigned to x, the
-                        two CPUs of the VM will be assigned to y and z
-                        respectively, and the workload will be run on y. These
-                        CPUs should be isolated (i.e. start your machine with
-                        `isolcpus=x,y,z`). Keep this list empty to not assign
-                        CPUs
+  -c CPU-QEMU CPU-KVM1 CPU-KVM2, --cpu CPU-QEMU CPU-KVM1 CPU-KVM2
+                        CPUs that should be used to run the VM. Qemu-system
+                        will be assigned to `CPU-QEMU`, the two CPUs of the VM
+                        will be assigned to `CPU-KVM1` and `CPU-KVM2`
+                        respectively, and the workload will be run on `CPU-
+                        KVM1`. These CPUs should be isolated (i.e. start your
+                        machine with `isolcpus=CPU-QEMU,CPU-KVM1,CPU-KVM2`.
+                        Omit this parameter to not assign CPUs
 ```
 
 You can give as many kernels as you want (`-k`). They will all be evaluated several times and the results will be written in the output file (`-o`). You also need to provide the image (`-i`) with the authorized ssh key (-`key`). The progress will be displayed in stdout.

--- a/lsm-perf.py
+++ b/lsm-perf.py
@@ -64,6 +64,9 @@ def evaluate_kernel(kernel_path, filesystem_img_path, workload_path,
     :param keyfile: Path of the rsa key that is authorized on the image
     :param cpus: CpuAllocation for qemu and the vm's cores,
                  or None to not assign CPUs
+    :param runs: Number of measured executions of the workload
+    :param warmups: Number of unmeasured executions of the workload
+                    before starting the measurements
     :return: time measurements printed by each run of the workload
     :rtype: list[int]
     """
@@ -210,6 +213,7 @@ class VM:
     @staticmethod
     def __qemu_affinity_setup(qemu_pid, cpu_alloc):
         """Run qemu_affinity.py to allocate CPUs based on the CpuAllocation"""
+        time.sleep(0.5)  # ensure that the qemu processes started
         system_affinities = ('-p %(sys)d -i *:%(sys)d -q %(sys)d -w *:%(sys)d'
                              % {'sys': cpu_alloc.qemu_sys}).split(' ')
         kvm_affinities = ['-k', str(cpu_alloc.host_kvm0),

--- a/lsm-perf.py
+++ b/lsm-perf.py
@@ -14,9 +14,7 @@ ON_VM_WORKLOAD_PATH = '~/lsm-perf-workload'
 ON_VM_WORKLOAD_CPU = 0
 HOST_PORT = 5555
 SSH_MAX_RETRY = 5
-
-# TODO(renauld): make generic
-QEMU_AFFINITY_PATH = '../qemu-affinity/qemu_affinity.py'
+QEMU_AFFINITY_PATH = './qemu-affinity/qemu_affinity.py'
 
 
 """Holds the assignment of physical CPUs"""
@@ -217,7 +215,7 @@ class VM:
         kvm_affinities = ['-k', str(cpu_alloc.host_kvm0),
                                 str(cpu_alloc.host_kvm1)]
         args = system_affinities + kvm_affinities + ['--', str(qemu_pid)]
-        cmd = plumbum.cmd.sudo['python3'][QEMU_AFFINITY_PATH][args]
+        cmd = plumbum.cmd.sudo[sys.executable][QEMU_AFFINITY_PATH][args]
         return cmd()
 
 

--- a/lsm-perf.py
+++ b/lsm-perf.py
@@ -272,19 +272,16 @@ def parse_args():
         '-o', '--out', type=argparse.FileType('w'), default='lsm-perf.csv',
         help='Path of the output file.')
     parser.add_argument(
-        '-c', '--cpu', type=int, default=[], nargs='*',
-        help=('CPUs that should be used to run the VM. '
-              'Provide three CPUs [x,y,z], qemu-system will be assigned '
-              'to x, the two CPUs of the VM will be assigned to y and z '
-              'respectively, and the workload will be run on y. '
-              'These CPUs should be isolated '
-              '(i.e. start your machine with `isolcpus=x,y,z`). '
-              'Keep this list empty to not assign CPUs'))
-    args = parser.parse_args()
-    if len(args.cpu) not in [0, 3]:
-        parser.error(
-            'Incorrect number of CPUs provided: expects either 0 or 3')
-    return args
+        '-c', '--cpu', type=int, nargs=3,
+        metavar=('CPU-QEMU', 'CPU-KVM1', 'CPU-KVM2'),
+        help=('CPUs that should be used to run the VM. Qemu-system will '
+              'be assigned to `CPU-QEMU`, the two CPUs of the VM will be '
+              'assigned to `CPU-KVM1` and `CPU-KVM2` respectively, and '
+              'the workload will be run on `CPU-KVM1`. These CPUs should '
+              'be isolated (i.e. start your machine with '
+              '`isolcpus=CPU-QEMU,CPU-KVM1,CPU-KVM2`. '
+              'Omit this parameter to not assign CPUs'))
+    return parser.parse_args()
 
 
 if __name__ == "__main__":

--- a/lsm-perf.py
+++ b/lsm-perf.py
@@ -213,7 +213,6 @@ class VM:
     @staticmethod
     def __qemu_affinity_setup(qemu_pid, cpu_alloc):
         """Run qemu_affinity.py to allocate CPUs based on the CpuAllocation"""
-        time.sleep(0.5)  # ensure that the qemu processes started
         system_affinities = ('-p %(sys)d -i *:%(sys)d -q %(sys)d -w *:%(sys)d'
                              % {'sys': cpu_alloc.qemu_sys}).split(' ')
         kvm_affinities = ['-k', str(cpu_alloc.host_kvm0),


### PR DESCRIPTION
Clean up the code and make it is useable directly, without modifying the constants.

This patch contains several small fixes: 
 - Include qemu-affinity as a git submodule (see readme for usage), and execute it with `sys.executor`
 - Make the `-c` option take exactly 3 arguments for cleaner help message
 - Replace `-key` by `--key` for consistency
 - Add the optionnal arguments `--runs`, `--rounds`, `--warmups` to replace constants
 - Improve stdout while running
 - Update readme to reflect changes