### PR TITLE
Correct timing bug

### DIFF
--- a/lsm-perf.py
+++ b/lsm-perf.py
@@ -151,6 +151,7 @@ class VM:
             filesystem_img_path=filesystem_img_path,
             isolcpus=isolcpus)
         self.process = local['qemu-system-x86_64'].popen(qemu_args)
+        time.sleep(0.1)  # let the qemu processes start
         self.ssh = None
         self.key = keyfile
         if cpu_allocation:
@@ -179,6 +180,7 @@ class VM:
             self.ssh.close()
             self.ssh = None
         self.process.terminate()
+        time.sleep(0.1)  # wait for the process to exit
 
     def scp_to(self, src_local, dst_remote):
         """Send a file from the host to the VM


### PR DESCRIPTION
Rarely, lsm-perf.py would run tino timing issues.
One happens when the VM is started and qemu-affinity
is ran with the assumption that all the qemu processes
already exist. Sometimes, these qemu processes were not
started yet and qemu-affinity crashes.

Similarly, when the VM is terminated and another VM is started
right after, a conflict could arise were both VMs would exist
at the same time.

By adding time.sleep(0.1), the other processes have time to
initialize/terminate correctly before proceeding.